### PR TITLE
Fix Event timedelta bug and description string typo

### DIFF
--- a/transitsync_routing/event.py
+++ b/transitsync_routing/event.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Any
 
 class Event:
@@ -85,7 +85,7 @@ class Event:
         elif self.start_time:
             # Default to start_time + 1 hour if no end time is specified
             event_dict["end"] = {
-                "dateTime": (self.start_time + datetime.timedelta(hours=1)).isoformat(),
+                "dateTime": (self.start_time + timedelta(hours=1)).isoformat(),
                 "timeZone": self.time_zone,
             }
         

--- a/transitsync_routing/route_planner.py
+++ b/transitsync_routing/route_planner.py
@@ -345,7 +345,7 @@ class RoutePlanner:
                             "🚌 PUBLIC TRANSIT INFORMATION 🚌\n\n"
                             f"From: {route.get('from_event')} ({route.get('from_location')})\n"
                             f"To: {route.get('to_event')} ({route.get('to_location')})\n\n"
-                            f"⏱️ Travel time: {route.get('estimated_travel_time_minutes']:.1f} minutes\n"
+                            f"⏱️ Travel time: {route.get('estimated_travel_time_minutes', 0):.1f} minutes\n"
                             f"⏰ Depart at: {formatted_dep}\n"
                             f"🏁 Arrive by: {formatted_arr}\n"
                         )


### PR DESCRIPTION
## Summary
- import `timedelta` in `event.py` and use it when generating default end time
- fix malformed f-string in `route_planner.py`

## Testing
- `python -m py_compile main_cli.py transitsync_routing/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684104327f14832ead9ec3293a1c8b3b